### PR TITLE
Fix false positives for strings containing hex color codes anywhere within

### DIFF
--- a/lib/isHex.js
+++ b/lib/isHex.js
@@ -3,7 +3,7 @@
 const hexRegex = require('hex-color-regex');
 
 function isHex(str) {
-  return hexRegex({ exact: true }).test(str);
+  return hexRegex({ strict: true }).test(str);
 }
 
 module.exports = isHex;

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -33,6 +33,7 @@ describe('is-color-stop', function () {
 
   it('isHex', function () {
     assert.ok(isColorStop.isHex('#123456'));
+    assert.ok(!isColorStop.isHex('foo#123456'));
   });
 
   it('isCSSColorName', function () {


### PR DESCRIPTION
This fixes false positives for strings like "foo#123".

Option name for hex-color-regex is `strict` as opposed to `exact` as with the other regex libraries.

Fixes #12